### PR TITLE
docs(readme): clarify Vitess/MySQL vs Postgres

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Connecting to PlanetScale from Go
 
-> **Note:** This example uses [`go-sql-driver/mysql`](https://github.com/go-sql-driver/mysql) for PlanetScale Vitess/MySQL. PlanetScale also offers managed PostgreSQL; use a PostgreSQL driver (for example [`pgx`](https://github.com/jackc/pgx) or [`lib/pq`](https://github.com/lib/pq)) and Postgres connection settings for those databases. For more information and examples, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
+> **Note:** This example targets PlanetScale Vitess/MySQL. PlanetScale also offers managed PostgreSQL. For more information, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
 
 This example demonstrates how to connect a Go application to a PlanetScale database using [`go-sql-driver/mysql`](https://github.com/go-sql-driver/mysql).
 

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # Connecting to PlanetScale from Go
 
+> **Note:** This example uses [`go-sql-driver/mysql`](https://github.com/go-sql-driver/mysql) for PlanetScale Vitess/MySQL. PlanetScale also offers managed PostgreSQL; use a PostgreSQL driver (for example [`pgx`](https://github.com/jackc/pgx) or [`lib/pq`](https://github.com/lib/pq)) and Postgres connection settings for those databases. For more information and examples, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
+
 This example demonstrates how to connect a Go application to a PlanetScale database using [`go-sql-driver/mysql`](https://github.com/go-sql-driver/mysql).
 
 Follow the instructions below to find and insert your PlanetScale credentials.

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Connecting to PlanetScale from Go
 
-> **Note:** This example targets PlanetScale Vitess/MySQL. PlanetScale also offers managed PostgreSQL. For more information, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
+> **Note:** This example targets PlanetScale Vitess/MySQL. PlanetScale also offers managed Postgres. For more information, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
 
 This example demonstrates how to connect a Go application to a PlanetScale database using [`go-sql-driver/mysql`](https://github.com/go-sql-driver/mysql).
 


### PR DESCRIPTION
## Summary

- README: clarify that this repository targets PlanetScale Vitess/MySQL (or the MySQL tooling shown in the repo), not PlanetScale-only-MySQL.
- Link readers to Postgres documentation at https://planetscale.com/docs/postgres for managed PostgreSQL databases.

PlanetScale offers both MySQL-compatible (Vitess) and PostgreSQL products.

Made with [Cursor](https://cursor.com)